### PR TITLE
Add: Manejo del fuego amigo, resolucion de errores y actualizacion de los equipos

### DIFF
--- a/src/main/java/unmineraft/unicons/UNIcons.java
+++ b/src/main/java/unmineraft/unicons/UNIcons.java
@@ -7,6 +7,7 @@ import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+import unmineraft.unicons.events.FriendlyFireEvent;
 import unmineraft.unicons.events.SelectTeamEvent;
 import unmineraft.unicons.teams.TeamsConfigConsumer;
 import unmineraft.unicons.utilities.FileManager;
@@ -29,6 +30,7 @@ public final class UNIcons extends JavaPlugin {
     public void eventsRegister(){
         PluginManager pluginManager = getServer().getPluginManager();
         pluginManager.registerEvents(new SelectTeamEvent(this), this);
+        pluginManager.registerEvents(new FriendlyFireEvent(this), this);
     }
 
     public void configRegister(){

--- a/src/main/java/unmineraft/unicons/events/FriendlyFireEvent.java
+++ b/src/main/java/unmineraft/unicons/events/FriendlyFireEvent.java
@@ -1,0 +1,52 @@
+package unmineraft.unicons.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import unmineraft.unicons.UNIcons;
+import unmineraft.unicons.teams.TeamsBuilder;
+
+import java.util.UUID;
+
+public class FriendlyFireEvent implements Listener {
+    private boolean disableFF = false;
+
+    @EventHandler
+    public void disabledFriendlyFire(EntityDamageByEntityEvent event){
+        if (!this.disableFF) return;
+
+        // Target
+        if (!(event.getEntity() instanceof Player)) return;
+        Player target = (Player) event.getEntity();
+
+        // Damager
+        if (!(event.getDamager() instanceof  Player)) return;
+        Player damager = (Player) event.getDamager();
+
+        // Verify Teams
+        UUID targetID = target.getUniqueId();
+        UUID damagerID = damager.getUniqueId();
+
+        // In case the players does not have a team
+        if (!(TeamsBuilder.PLAYER_TEAM.containsKey(targetID))) return;
+        if (!(TeamsBuilder.PLAYER_TEAM.containsKey(damagerID))) return;
+
+        // In case the players have different team
+        String targetTeam = TeamsBuilder.PLAYER_TEAM.get(targetID);
+        String damagerTeam = TeamsBuilder.PLAYER_TEAM.get(damagerID);
+
+        if (!(targetTeam.equals(damagerTeam))) return;
+
+        // In case the player have a same team
+        event.setCancelled(true);
+    }
+
+
+    public FriendlyFireEvent(UNIcons plugin){
+        String confBoolean = plugin.getConfig().getString("config.friendlyFire");
+        if (confBoolean == null) return;
+
+        this.disableFF = confBoolean.equalsIgnoreCase("false");
+    }
+}

--- a/src/main/java/unmineraft/unicons/teams/TeamsBuilder.java
+++ b/src/main/java/unmineraft/unicons/teams/TeamsBuilder.java
@@ -185,6 +185,9 @@ public class TeamsBuilder {
     }
 
     public void addMember(Player player){
+        // To avoid overwriting groups
+        if (TeamsBuilder.PLAYER_TEAM.containsKey(player.getUniqueId())) return;
+
         this.addPlayer(player);
         TeamsBuilder.PLAYER_TEAM.put(player.getUniqueId(), this.name);
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -55,19 +55,19 @@ groups:
       # tag_prefix: "[ICO_UD]"
       # tag_suffix: ""
       # sort_priority: 1
-  upn:
+  oua:
     general:
       permissions:
         - "blockball.game.join.all"
         - "essentials.chat"
-        - "nte.upn"
+        - "nte.oua"
     # tab:
-      # tab_prefix: "[UPN]"
+      # tab_prefix: "[OUA]"
       # tab_name: "%player%"
       # tab_suffix: ""
     scoreboard:
-      work_name: "UPN_LOVER"
+      work_name: "OUA_LOVER"
     # tag_name:
-      # tag_prefix: "[ICO_UPN]"
+      # tag_prefix: "[ICO_OUA]"
       # tag_suffix: ""
       # sort_priority: 1

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,7 @@ config:
     #NameTagEdit: "/NametagEdit/groups.yml"
     #TabList: "/TabList/groups.yml"
   #separator: "########## UNICONS_MANAGEMENT_%LOCATION% ##########"
+  friendlyFire: false
 groups:
   un:
     general:


### PR DESCRIPTION
- Se implementa a través del archivo de configuración la eliminación del daño entre jugadores del mismo grupo
- La UPN cambia a OUA
- Se elimina, maneja el caso de sobrescritura de grupos, que generaba un error a la hora de validar el grupo del jugador